### PR TITLE
Isamumu/dedup

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -53,7 +53,7 @@
     </div>
     
     <button id="openAddButton">Add Member</button>
-    <form id='addForm' class='formOverlay' action='https://usk4xisdph.execute-api.us-east-2.amazonaws.com/members' method='POST'>
+    <form id='addForm' class='formOverlay' action='https://j5z43ef3j0.execute-api.us-east-2.amazonaws.com/items' method='POST'>
         <label for="addFirstName">First Name (Required)</label>
         <input type="text" id="addFirstName" name="first_name" required>
         <label for="addLastName">Last Name (Required)</label>

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -6,7 +6,7 @@ let members = null;
 
 async function renderTable() {
     try {
-        const response = await fetch('https://usk4xisdph.execute-api.us-east-2.amazonaws.com/members');
+        const response = await fetch('https://j5z43ef3j0.execute-api.us-east-2.amazonaws.com/items');
         if (!response.ok) throw new Error(`HTTP error ${response.status}`);
 
         const data = await response.json();
@@ -175,7 +175,7 @@ document.getElementById('saveButton').addEventListener('click', async () => {
         const newRankType = document.getElementById('editRankType').value;
         const newRankNumber = parseInt(document.getElementById('editRankNumber').value, 10);
 
-        const response = await fetch('https://usk4xisdph.execute-api.us-east-2.amazonaws.com/members', {
+        const response = await fetch('https://j5z43ef3j0.execute-api.us-east-2.amazonaws.com/items', {
             method: 'PATCH',
             headers: {
                 'Content-Type': 'application/json',
@@ -215,7 +215,7 @@ document.getElementById('removeButton').addEventListener('click', async () => {
             return;
         }
 
-        const response = await fetch('https://usk4xisdph.execute-api.us-east-2.amazonaws.com/members', {
+        const response = await fetch('https://j5z43ef3j0.execute-api.us-east-2.amazonaws.com/items', {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json',
@@ -265,7 +265,7 @@ document.getElementById('addForm').addEventListener('submit', async function(eve
         const newRankType = document.getElementById('addRankType').value;
         const newRankNumber = parseInt(document.getElementById('addRankNumber').value, 10);
 
-        const response = await fetch('https://usk4xisdph.execute-api.us-east-2.amazonaws.com/members', {
+        const response = await fetch('https://j5z43ef3j0.execute-api.us-east-2.amazonaws.com/items', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -308,7 +308,7 @@ document.getElementById('groupCsvInput').addEventListener('change', async (event
     try {
         const user = await userManager.getUser();
         if (!user || user.expired) {
-            alert("You must be signed in to remove a member.");
+            alert("You must be signed in to add a member.");
             return;
         }
         const file = event.target.files[0];
@@ -363,7 +363,7 @@ document.getElementById('groupCsvInput').addEventListener('change', async (event
                         }
                     }
 
-                    const response = await fetch('https://usk4xisdph.execute-api.us-east-2.amazonaws.com/members', {
+                    const response = await fetch('https://j5z43ef3j0.execute-api.us-east-2.amazonaws.com/items', {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -199,7 +199,8 @@ document.getElementById('saveButton').addEventListener('click', async () => {
         document.getElementById('shelf').innerHTML = '';
         await renderTable();  // ✅ WAIT for rendering to complete
 
-        console.log("✅ Save and render complete.");
+        const data = await response.json();
+        console.log("✅ Member added:", data);
 
     } catch (error) {
         console.error("❌ Failed to save or render table:", error);

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -119,6 +119,15 @@ export class InfraStack extends Stack {
       resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/members'],
     }));
 
+    modifyMemberLambda.addToRolePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['dynamodb:Query'],
+      resources: [
+        'arn:aws:dynamodb:us-east-2:222575804757:table/members',
+        'arn:aws:dynamodb:us-east-2:222575804757:table/members/index/dedup_key-index'
+      ],
+    }));
+
     // Add routes
     httpApi.addRoutes({
       path: '/items',

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -68,6 +68,7 @@ export class InfraStack extends Stack {
       apiName: 'membersAPI_CDK',
       corsPreflight: {
         allowHeaders: ['*'],
+        exposeHeaders: ['*'],
         allowMethods: [
           apigwv2.CorsHttpMethod.GET,
           apigwv2.CorsHttpMethod.POST,
@@ -82,25 +83,40 @@ export class InfraStack extends Stack {
     getMembersLambda.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['dynamodb:Scan'],
-      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/sdkb'],
+      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/members'],
     }));
 
     createMemberLambda.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['dynamodb:PutItem'],
-      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/sdkb'],
+      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/members'],
+    }));
+
+    createMemberLambda.addToRolePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['dynamodb:UpdateItem'],
+      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/appConfigs'],
+    }));
+
+    createMemberLambda.addToRolePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['dynamodb:Query'],
+      resources: [
+        'arn:aws:dynamodb:us-east-2:222575804757:table/members',
+        'arn:aws:dynamodb:us-east-2:222575804757:table/members/index/dedup_key-index'
+      ],
     }));
 
     removeMemberLambda.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['dynamodb:DeleteItem'],
-      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/sdkb'],
+      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/members'],
     }));
 
     modifyMemberLambda.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['dynamodb:UpdateItem'],
-      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/sdkb'],
+      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/members'],
     }));
 
     // Add routes

--- a/lambdas/createMember/index.js
+++ b/lambdas/createMember/index.js
@@ -22,12 +22,8 @@ exports.handler = async (event) => {
     };
     const updateResult = await ddb.send(new UpdateCommand(updateParams));
     const newMemberId = updateResult.Attributes.idCounter;
-
     const data = JSON.parse(event.body);
-
     const dedupKey = `${data.first_name.toLowerCase()}#${data.last_name.toLowerCase()}#${data.rank_type.toLowerCase()}#${data.rank_number}#${data.zekken_text}`;
-
-    console.log(`Deduplication key: ${dedupKey}`);
 
     const query = new QueryCommand({
       TableName: 'members',

--- a/lambdas/createMember/index.js
+++ b/lambdas/createMember/index.js
@@ -24,6 +24,8 @@ exports.handler = async (event) => {
 
     const data = JSON.parse(event.body);
 
+    const dedupKey = `${data.first_name.toLowerCase()}#${data.last_name.toLowerCase()}#${data.rank_type.toLowerCase()}#${data.rank_number}#${data.zekken_text}`;
+
     const params = {
       TableName: "members",
       Item: {

--- a/lambdas/createMember/index.js
+++ b/lambdas/createMember/index.js
@@ -1,4 +1,4 @@
-const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
+const { DynamoDBClient, QueryCommand } = require("@aws-sdk/client-dynamodb");
 const {
   DynamoDBDocumentClient,
   PutCommand,


### PR DESCRIPTION
Currently there is nothing that protects against entries that have the same fields, excluding the memberID. Our ddb table now has an index that is generated to make our table items queryable. This PR addresses this change and revises the implementation to check for duplicates during member creation, and also when updating members.