### PR TITLE
use cognito groups

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -37,7 +37,7 @@ body {
     width: 70px;
     height: 300px;
     perspective: 1000px;
-    transform: translateZ(0);
+    -webkit-perspective: 1000px;
 }
 
 .slip {
@@ -45,15 +45,16 @@ body {
     height: 100%;
     position: relative;
     transform-style: preserve-3d;
+    -webkit-transform-style: preserve-3d;
     transition: transform 0.6s ease-in-out;
     background-color: #c79b63;
     background-image: url("../assets/images/bamboo.png");
     border: 2px solid #555;
-    will-change: transform;
 }
 
 .slip.flipped {
     transform: rotateY(180deg);
+    -webkit-transform: rotateY(180deg);
 }
 
 .front, .back {
@@ -64,14 +65,18 @@ body {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+
     backface-visibility: hidden;
-    flex-wrap: wrap;
-    overflow: hidden;
-    transform: translateZ(0);
+    -webkit-backface-visibility: hidden;
+
+    transform: translateZ(0.001px);
+    -webkit-transform: translateZ(0.001px);
+
 }
 
 .back {
     transform: rotateY(180deg);
+    -webkit-transform: rotateY(180deg) translateZ(0.001px);
 }
 
 .kanjiLarge {

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -164,12 +164,6 @@ export class InfraStack extends Stack {
       resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/members'],
     }));
 
-    getAdminLambda.addToRolePolicy(new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      actions: ['dynamodb:GetItem'],
-      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/admins'],
-    }))
-
     createMemberLambda.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['dynamodb:PutItem'],

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -178,12 +178,6 @@ export class InfraStack extends Stack {
 
     createMemberLambda.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
-      actions: ['dynamodb:GetItem'],
-      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/admins'],
-    }));
-
-    createMemberLambda.addToRolePolicy(new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
       actions: ['dynamodb:UpdateItem'],
       resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/appConfigs'],
     }));
@@ -203,12 +197,6 @@ export class InfraStack extends Stack {
       resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/members'],
     }));
 
-    removeMemberLambda.addToRolePolicy(new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      actions: ['dynamodb:GetItem'],
-      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/admins'],
-    }));
-
     modifyMemberLambda.addToRolePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['dynamodb:UpdateItem'],
@@ -222,12 +210,6 @@ export class InfraStack extends Stack {
         'arn:aws:dynamodb:us-east-2:222575804757:table/members',
         'arn:aws:dynamodb:us-east-2:222575804757:table/members/index/dedup_key-index'
       ],
-    }));
-
-    modifyMemberLambda.addToRolePolicy(new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      actions: ['dynamodb:GetItem'],
-      resources: ['arn:aws:dynamodb:us-east-2:222575804757:table/admins'],
     }));
 
     lookupByEmailLambda.addToRolePolicy(new iam.PolicyStatement({

--- a/lambdas/getAdmin/index.js
+++ b/lambdas/getAdmin/index.js
@@ -1,48 +1,47 @@
-const { DynamoDBClient } = require ("@aws-sdk/client-dynamodb");
-const { DynamoDBDocumentClient, GetCommand } = require ("@aws-sdk/lib-dynamodb");
+function normalizeGroups(raw) {
+  if (Array.isArray(raw)) {
+    return raw.flatMap(item => normalizeGroups(item)); // handle nested / mixed shapes
+  }
+  const s = String(raw || '').trim();
 
-const client = new DynamoDBClient({});
-const ddb = DynamoDBDocumentClient.from(client);
-const ADMIN_TABLE = "admins";
+  // If the value is like "[a, b, c]" (stringified array), strip brackets first
+  const withoutBrackets = (s.startsWith('[') && s.endsWith(']')) ? s.slice(1, -1) : s;
 
-const makeLowerCase = inputString => (inputString ?? "").toString().trim().toLowerCase();
-const deny = (msg="Forbidden") => ({
-  statusCode: 403,
-  headers: {
-    "Content-Type": "text/plain",
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "Authorization,Content-Type",
-  },
-  body: msg
-});
+  // Split by comma, trim entries, drop empties
+  return withoutBrackets
+    .split(',')
+    .map(x => x.trim())
+    .filter(Boolean);
+}
 
 exports.handler = async (event) => {
-  const auth = event.requestContext?.authorizer || {};
-  const claims = auth.claims || (auth.jwt && auth.jwt.claims) || {};
-  const emailFromClaims = makeLowerCase(claims.email);
-  let email = emailFromClaims;
-  if (!email) return deny("No email claim. Ensure you sent the ID token and requested 'email' scope.");
-  
-  try {
-    const command = new GetCommand({ TableName: ADMIN_TABLE, Key: { email } });
-    const result = await ddb.send(command);
-    return {
-      statusCode: 200,
-      headers: {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*"
-      },
-      body: JSON.stringify({
-        message: "Retrieved matching admins",
-        item: result.Item ?? null,
-        isAdmin: result.Item ? true : false
-      })
-    };
-  } catch (err) {
-    return {
-      statusCode: 500,
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ error: err.message })
-    };
+  const claims =
+    event.requestContext?.authorizer?.jwt?.claims ??
+    event.requestContext?.authorizer?.claims ??
+    {};
+
+  const groups = normalizeGroups(claims['cognito:groups']);
+  const isAdmin = groups.some(g => g === 'admins' || g.endsWith(' admins'));
+
+  console.log('Auth debug', {
+    email: claims.email,
+    groups,
+    token_use: claims.token_use,
+  });
+
+  if (!isAdmin) {
+    return { statusCode: 403, body: 'Forbidden' };
   }
+  
+  return {
+    statusCode: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*"
+    },
+    body: JSON.stringify({
+      message: "Retrieved matching admins",
+      isAdmin: isAdmin ? true : false
+    })
+  };
 };

--- a/lambdas/modifyMember/index.js
+++ b/lambdas/modifyMember/index.js
@@ -2,7 +2,6 @@ const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const {
   DynamoDBDocumentClient,
   QueryCommand,
-  GetCommand,
   UpdateCommand
 } = require("@aws-sdk/lib-dynamodb");
 
@@ -12,32 +11,44 @@ const ddb = DynamoDBDocumentClient.from(client);
 
 const MEMBERS_TABLE = "members";
 const DEDUP_INDEX   = "dedup_key-index";
-const ADMIN_TABLE = "admins";
 
 const lc = v => (v ?? "").toString().trim().toLowerCase();
 
-const deny = (msg="Forbidden") => ({
-  statusCode: 403,
-  headers: {
-    "Content-Type": "text/plain",
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "Authorization,Content-Type",
-  },
-  body: msg
-});
+function normalizeGroups(raw) {
+  if (Array.isArray(raw)) {
+    return raw.flatMap(item => normalizeGroups(item)); // handle nested / mixed shapes
+  }
+  const s = String(raw || '').trim();
+
+  // If the value is like "[a, b, c]" (stringified array), strip brackets first
+  const withoutBrackets = (s.startsWith('[') && s.endsWith(']')) ? s.slice(1, -1) : s;
+
+  // Split by comma, trim entries, drop empties
+  return withoutBrackets
+    .split(',')
+    .map(x => x.trim())
+    .filter(Boolean);
+}
 
 exports.handler = async (event) => {
   // Prefer claims from API Gateway authorizer (ID token path)
-  const auth = event.requestContext?.authorizer || {};
-  const claims = auth.claims || (auth.jwt && auth.jwt.claims) || {};
-  const emailFromClaims = lc(claims.email);
+  const claims =
+    event.requestContext?.authorizer?.jwt?.claims ??
+    event.requestContext?.authorizer?.claims ??
+    {};
 
-  let email = emailFromClaims;
+  const groups = normalizeGroups(claims['cognito:groups']);
+  const isAdmin = groups.some(g => g === 'admins' || g.endsWith(' admins'));
 
-  if (!email) return deny("No email claim. Ensure you sent the ID token and requested 'email' scope.");
-  
-  const { Item } = await ddb.send(new GetCommand({ TableName: ADMIN_TABLE, Key: { email } }));
-  if (!Item) return deny("Admin only");
+  console.log('Auth debug', {
+    email: claims.email,
+    groups,
+    token_use: claims.token_use,
+  });
+
+  if (!isAdmin) {
+    return { statusCode: 403, body: 'Forbidden' };
+  }
 
   try { 
     const data = JSON.parse(event.body);

--- a/lambdas/removeMember/index.js
+++ b/lambdas/removeMember/index.js
@@ -5,36 +5,46 @@ const {
   DeleteCommand
 } = require("@aws-sdk/lib-dynamodb");
 
-const ADMIN_TABLE = "admins";
 const MEMBERS_TABLE = "members";
 
 const client = new DynamoDBClient({});
 const ddb = DynamoDBDocumentClient.from(client);
 
-const lc = (v) => (v ?? "").toString().trim().toLowerCase();
+function normalizeGroups(raw) {
+  if (Array.isArray(raw)) {
+    return raw.flatMap(item => normalizeGroups(item)); // handle nested / mixed shapes
+  }
+  const s = String(raw || '').trim();
 
-const deny = (msg="Forbidden") => ({
-  statusCode: 403,
-  headers: {
-    "Content-Type": "text/plain",
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "Authorization,Content-Type",
-  },
-  body: msg
-});
+  // If the value is like "[a, b, c]" (stringified array), strip brackets first
+  const withoutBrackets = (s.startsWith('[') && s.endsWith(']')) ? s.slice(1, -1) : s;
+
+  // Split by comma, trim entries, drop empties
+  return withoutBrackets
+    .split(',')
+    .map(x => x.trim())
+    .filter(Boolean);
+}
 
 exports.handler = async (event) => {
   // Prefer claims from API Gateway authorizer (ID token path)
-  const auth = event.requestContext?.authorizer || {};
-  const claims = auth.claims || (auth.jwt && auth.jwt.claims) || {};
-  const emailFromClaims = lc(claims.email);
+  const claims =
+    event.requestContext?.authorizer?.jwt?.claims ??
+    event.requestContext?.authorizer?.claims ??
+    {};
 
-  let email = emailFromClaims;
+  const groups = normalizeGroups(claims['cognito:groups']);
+  const isAdmin = groups.some(g => g === 'admins' || g.endsWith(' admins'));
 
-  if (!email) return deny("No email claim. Ensure you sent the ID token and requested 'email' scope.");
-  
-  const { Item } = await ddb.send(new GetCommand({ TableName: ADMIN_TABLE, Key: { email } }));
-  if (!Item) return deny("Admin only");
+  console.log('Auth debug', {
+    email: claims.email,
+    groups,
+    token_use: claims.token_use,
+  });
+
+  if (!isAdmin) {
+    return { statusCode: 403, body: 'Forbidden' };
+  }
   
   try {
     const data = JSON.parse(event.body);

--- a/lambdas/removeMember/index.js
+++ b/lambdas/removeMember/index.js
@@ -1,7 +1,6 @@
 const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const {
   DynamoDBDocumentClient,
-  GetCommand,
   DeleteCommand
 } = require("@aws-sdk/lib-dynamodb");
 


### PR DESCRIPTION
currently we do a lookup onto admins database to figure out if a user is admin or not. Instead we should be using cognito groups since it is less costly than looking up a database. 