### PR TITLE
events frontend

### DIFF
--- a/frontend/css/events.module.css
+++ b/frontend/css/events.module.css
@@ -311,3 +311,39 @@
   color: #6c757d;
   font-size: 0.75rem;
 }
+
+.signupBtn {
+  background: #0d6efd;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.3rem 1rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: background 0.2s;
+}
+
+.signupBtn:hover { background: #0b5ed7; }
+.signupBtn:disabled { background: #444; cursor: not-allowed; }
+
+.toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #157347;
+  color: #fff;
+  padding: 0.6rem 1.4rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+
+.fieldError {
+  color: #e05252;
+  font-size: 0.8rem;
+  margin-top: -0.25rem;
+}

--- a/frontend/src/pages/Events.jsx
+++ b/frontend/src/pages/Events.jsx
@@ -2,8 +2,11 @@ import { useState, useEffect } from 'react';
 import styles from '../../css/events.module.css';
 import { userManager } from '../js/cognitoManager';
 
-const EVENTS_API = 'https://qh3c0tz6s9.execute-api.us-east-2.amazonaws.com/events';
-const CONFIGURE_API = 'https://qh3c0tz6s9.execute-api.us-east-2.amazonaws.com/events/configure';
+const BASE_URL = 'https://qh3c0tz6s9.execute-api.us-east-2.amazonaws.com';
+const EVENTS_API = `${BASE_URL}/events`;
+const CONFIGURE_API = `${BASE_URL}/events/configure`;
+const PAYMENTS_API = `${BASE_URL}/payments`;
+const SUBMITTED_PAYMENTS_API = `${BASE_URL}/submittedpayments`;
 
 const STATUS_COLORS = {
   Past: '#6c757d',
@@ -11,7 +14,7 @@ const STATUS_COLORS = {
   Upcoming: '#0d6efd',
 };
 
-const EMPTY_FORM = { title: '', description: '', start_datetime: '', end_datetime: '', location: '', type: '' };
+const EMPTY_FORM = { title: '', description: '', start_datetime: '', end_datetime: '', location: '', type: '', payment_id: '' };
 const EMPTY_CONFIG = { shinpan_needed: false, event_deadline: '', divisions: '', teams_included: false, shinsa_levels: '', seminar_guests: '', bring_your_lunch: false };
 
 function getStatus(start, end) {
@@ -53,7 +56,7 @@ function toIso(inputValue) {
   return inputValue ? inputValue + ':00Z' : null;
 }
 
-function EventForm({ form, setForm, onSave, onCancel, title }) {
+function EventForm({ form, setForm, onSave, onCancel, title, availablePayments = [] }) {
   return (
     <div className={styles.formBox}>
       <p className={styles.formTitle}>{title}</p>
@@ -75,6 +78,16 @@ function EventForm({ form, setForm, onSave, onCancel, title }) {
         <option value="tournament">Tournament</option>
         <option value="shinsa">Shinsa</option>
         <option value="seminar">Seminar</option>
+      </select>
+      <label className={styles.label}>Payment (required)</label>
+      <select className={styles.input} value={form.payment_id}
+        onChange={e => setForm(f => ({ ...f, payment_id: e.target.value }))}>
+        <option value="">Select payment</option>
+        {availablePayments.map(p => (
+          <option key={p.payment_id} value={p.payment_id}>
+            {p.title} (#{p.payment_id})
+          </option>
+        ))}
       </select>
       <div className={styles.formActions}>
         <button className={styles.saveBtn} onClick={onSave}>Save</button>
@@ -145,6 +158,20 @@ function Events() {
   const [configuringId, setConfiguringId] = useState(null);
   const [configForm, setConfigForm] = useState(EMPTY_CONFIG);
   const [configs, setConfigs] = useState({});
+  const [payments, setPayments] = useState([]);
+  const [submittedPaymentIds, setSubmittedPaymentIds] = useState(new Set());
+  const [changingPaymentEventId, setChangingPaymentEventId] = useState(null);
+  const [changePaymentValue, setChangePaymentValue] = useState('');
+
+  useEffect(() => {
+    Promise.all([
+      fetch(PAYMENTS_API).then(r => r.json()).catch(() => ({ data: [] })),
+      fetch(SUBMITTED_PAYMENTS_API).then(r => r.json()).catch(() => ({ data: [] })),
+    ]).then(([paymentsData, sbmtData]) => {
+      setPayments(paymentsData.data || []);
+      setSubmittedPaymentIds(new Set((sbmtData.data || []).map(p => p.payment_id)));
+    });
+  }, []);
 
   useEffect(() => {
     fetch(EVENTS_API)
@@ -158,6 +185,7 @@ function Events() {
           end_datetime: e.event_deadline,
           location: e.event_location,
           type: e.event_type,
+          payment_id: e.payment_id ?? null,
         }));
         setEvents(evs);
         return evs;
@@ -189,7 +217,38 @@ function Events() {
     return matchFilter && matchSearch;
   });
 
+  const linkedPaymentIds = new Set(events.map(e => e.payment_id).filter(Boolean));
+  const baseAvailablePayments = payments.filter(p =>
+    !submittedPaymentIds.has(p.payment_id) && !linkedPaymentIds.has(p.payment_id)
+  );
+
+  function getPaymentsForEvent(eventId) {
+    const ev = events.find(e => e.event_id === eventId);
+    const ownPayment = ev?.payment_id ? payments.find(p => p.payment_id === ev.payment_id) : null;
+    if (ownPayment && !baseAvailablePayments.some(p => p.payment_id === ownPayment.payment_id)) {
+      return [...baseAvailablePayments, ownPayment];
+    }
+    return baseAvailablePayments;
+  }
+
+  function mapEvent(e) {
+    return {
+      event_id: e.event_id,
+      title: e.event_name,
+      description: '',
+      start_datetime: e.event_date,
+      end_datetime: e.event_deadline,
+      location: e.event_location,
+      type: e.event_type,
+      payment_id: e.payment_id ?? null,
+    };
+  }
+
   function handleCreate() {
+    if (!newForm.payment_id) {
+      setError('A payment must be linked to create an event.');
+      return;
+    }
     const payload = {
       event_name: newForm.title,
       event_type: newForm.type,
@@ -197,24 +256,17 @@ function Events() {
       event_location: newForm.location,
       event_deadline: toIso(newForm.end_datetime),
       created_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+      payment_id: parseInt(newForm.payment_id, 10),
     };
     userManager.getUser().then(user => fetch(EVENTS_API, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${user.id_token}` },
       body: JSON.stringify(payload),
     }))
-      .then(res => { if (!res.ok) throw new Error(`HTTP ${res.status}`); return res.json(); })
+      .then(res => { if (!res.ok) return res.json().then(b => { throw new Error(b.error || `HTTP ${res.status}`); }); return res.json(); })
       .then(() => fetch(EVENTS_API))
       .then(res => res.json())
-      .then(data => setEvents(data.body.map(e => ({
-        event_id: e.event_id,
-        title: e.event_name,
-        description: '',
-        start_datetime: e.event_date,
-        end_datetime: e.event_deadline,
-        location: e.event_location,
-        type: e.event_type,
-      }))))
+      .then(data => setEvents(data.body.map(mapEvent)))
       .catch(err => setError(err.message));
     setShowNew(false);
     setNewForm(EMPTY_FORM);
@@ -229,10 +281,15 @@ function Events() {
       end_datetime: toInputValue(ev.end_datetime),
       location: ev.location,
       type: ev.type,
+      payment_id: ev.payment_id ?? '',
     });
   }
 
   function handleEditSave() {
+    if (!editForm.payment_id) {
+      setError('A payment must be linked to the event.');
+      return;
+    }
     const payload = {
       event_id: editingId,
       event_name: editForm.title,
@@ -240,8 +297,8 @@ function Events() {
       event_date: toIso(editForm.start_datetime),
       event_deadline: toIso(editForm.end_datetime),
       event_location: editForm.location,
+      payment_id: parseInt(editForm.payment_id, 10),
     };
-    console.log('PATCH payload:', payload);
     setEditingId(null);
     userManager.getUser()
       .then(user => fetch(EVENTS_API, {
@@ -251,16 +308,24 @@ function Events() {
       }))
       .then(res => { if (!res.ok) return res.json().then(b => { throw new Error(b.message || b.error || `HTTP ${res.status}`); }); return fetch(EVENTS_API); })
       .then(res => res.json())
-      .then(data => setEvents(data.body.map(e => ({
-        event_id: e.event_id,
-        title: e.event_name,
-        description: '',
-        start_datetime: e.event_date,
-        end_datetime: e.event_deadline,
-        location: e.event_location,
-        type: e.event_type,
-      }))))
+      .then(data => setEvents(data.body.map(mapEvent)))
       .catch(err => setError(err.message));
+  }
+
+  function handleChangePaymentSave(ev) {
+    if (!changePaymentValue) return;
+    userManager.getUser()
+      .then(user => fetch(EVENTS_API, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${user.id_token}` },
+        body: JSON.stringify({ event_id: ev.event_id, payment_id: parseInt(changePaymentValue, 10) }),
+      }))
+      .then(res => { if (!res.ok) return res.json().then(b => { throw new Error(b.error || `HTTP ${res.status}`); }); })
+      .then(() => setEvents(prev => prev.map(e =>
+        e.event_id === ev.event_id ? { ...e, payment_id: parseInt(changePaymentValue, 10) } : e
+      )))
+      .catch(err => setError(err.message))
+      .finally(() => { setChangingPaymentEventId(null); setChangePaymentValue(''); });
   }
 
   function handleConfigureOpen(ev) {
@@ -340,6 +405,7 @@ function Events() {
           setForm={setNewForm}
           onSave={handleCreate}
           onCancel={() => setShowNew(false)}
+          availablePayments={baseAvailablePayments}
         />
       )}
 
@@ -381,6 +447,7 @@ function Events() {
                     setForm={setEditForm}
                     onSave={handleEditSave}
                     onCancel={() => setEditingId(null)}
+                    availablePayments={getPaymentsForEvent(editingId)}
                   />
                 ) : isConfiguring ? (
                   <ConfigureForm
@@ -456,11 +523,65 @@ function Events() {
                         </div>
                       );
                     })()}
+                    <div className={styles.configSection} style={{ marginTop: '0.5rem' }}>
+                      <div className={styles.configRow}>
+                        <span className={styles.configLabel}>Payment</span>
+                        {changingPaymentEventId === ev.event_id ? (
+                          <>
+                            <select
+                              className={styles.input}
+                              style={{ flex: 1, marginRight: '0.5rem' }}
+                              value={changePaymentValue}
+                              onChange={e => setChangePaymentValue(e.target.value)}
+                            >
+                              <option value="">Select payment</option>
+                              {getPaymentsForEvent(ev.event_id).map(p => (
+                                <option key={p.payment_id} value={p.payment_id}>
+                                  {p.title} (#{p.payment_id})
+                                </option>
+                              ))}
+                            </select>
+                            <button
+                              className={styles.saveBtn}
+                              style={{ padding: '0.2rem 0.6rem', fontSize: '0.75rem' }}
+                              onClick={() => handleChangePaymentSave(ev)}
+                              disabled={!changePaymentValue}
+                            >Save</button>
+                            <button
+                              className={styles.cancelBtn}
+                              style={{ padding: '0.2rem 0.6rem', fontSize: '0.75rem', marginLeft: '0.25rem' }}
+                              onClick={() => { setChangingPaymentEventId(null); setChangePaymentValue(''); }}
+                            >Cancel</button>
+                          </>
+                        ) : (
+                          <>
+                            {ev.payment_id ? (
+                              <span className={styles.configTag}>
+                                {payments.find(p => p.payment_id === ev.payment_id)?.title ?? `#${ev.payment_id}`}
+                                {' '}(#{ev.payment_id})
+                              </span>
+                            ) : (
+                              <span className={styles.configBoolFalse}>None</span>
+                            )}
+                            <button
+                              className={styles.editBtn}
+                              style={{ marginLeft: '0.5rem', padding: '0.15rem 0.5rem', fontSize: '0.75rem' }}
+                              onClick={() => {
+                                setChangingPaymentEventId(ev.event_id);
+                                setChangePaymentValue(ev.payment_id ? String(ev.payment_id) : '');
+                                setEditingId(null);
+                                setConfiguringId(null);
+                              }}
+                            >Change</button>
+                          </>
+                        )}
+                      </div>
+                    </div>
                     <div className={styles.cardActions}>
-                      <button className={styles.editBtn} onClick={() => { handleEditOpen(ev); setShowNew(false); setConfiguringId(null); }}>
+                      <button className={styles.editBtn} onClick={() => { handleEditOpen(ev); setShowNew(false); setConfiguringId(null); setChangingPaymentEventId(null); }}>
                         Edit
                       </button>
-                      <button className={styles.editBtn} onClick={() => { handleConfigureOpen(ev); setShowNew(false); setEditingId(null); }}>
+                      <button className={styles.editBtn} onClick={() => { handleConfigureOpen(ev); setShowNew(false); setEditingId(null); setChangingPaymentEventId(null); }}>
                         Configure
                       </button>
                       <button className={styles.deleteBtn} onClick={() => handleDelete(ev.event_id)}>

--- a/frontend/src/pages/EventsSignup.jsx
+++ b/frontend/src/pages/EventsSignup.jsx
@@ -1,0 +1,459 @@
+import { useState, useEffect, useRef } from 'react';
+import styles from '../../css/events.module.css';
+import { userManager } from '../js/cognitoManager';
+
+const BASE_URL = 'https://qh3c0tz6s9.execute-api.us-east-2.amazonaws.com';
+const EVENTS_API = `${BASE_URL}/events`;
+const CONFIGURE_API = `${BASE_URL}/events/configure`;
+const MEMBERS_API = `${BASE_URL}/members`;
+const REGISTER_API = `${BASE_URL}/events/register`;
+
+const STATUS_COLORS = {
+  Past: '#6c757d',
+  Ongoing: '#28a745',
+  Upcoming: '#0d6efd',
+};
+
+function getStatus(start, end) {
+  const now = new Date();
+  const s = new Date(start);
+  const e = end ? new Date(end) : s;
+  if (now < s) return 'Upcoming';
+  if (now > e) return 'Past';
+  return 'Ongoing';
+}
+
+function formatDateBadge(iso) {
+  const d = new Date(iso);
+  return {
+    day: d.getUTCDate(),
+    month: d.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' }).toUpperCase(),
+  };
+}
+
+function formatDateRange(start, end, location) {
+  const s = new Date(start);
+  const e = end ? new Date(end) : null;
+  const dateOpts = { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'UTC' };
+  const timeOpts = { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'UTC' };
+  const startStr = s.toLocaleDateString('en-GB', dateOpts);
+  const timeStr = s.toLocaleTimeString('en-GB', timeOpts);
+  if (e && e.toUTCString().slice(0, 16) !== s.toUTCString().slice(0, 16)) {
+    const endStr = e.toLocaleDateString('en-GB', dateOpts);
+    return `${startStr} – ${endStr} · ${timeStr} · ${location}`;
+  }
+  return `${startStr} · ${timeStr} · ${location}`;
+}
+
+function SignUpForm({ ev, config, onSubmit, onCancel, submitting }) {
+  const [division, setDivision] = useState('');
+  const [doingTeams, setDoingTeams] = useState(false);
+  const [shinpanning, setShinpanning] = useState(false);
+  const [testingFor, setTestingFor] = useState('');
+  const [divisionError, setDivisionError] = useState(false);
+
+  function handleSubmit() {
+    if (ev.type === 'tournament' && config?.divisions?.length > 0 && !division) {
+      setDivisionError(true);
+      return;
+    }
+    setDivisionError(false);
+    const extra = {};
+    if (ev.type === 'tournament') {
+      extra.division = division;
+      extra.doing_teams = doingTeams;
+      extra.shinpanning = shinpanning;
+    } else if (ev.type === 'shinsa') {
+      extra.testing_for = testingFor;
+    }
+    onSubmit(extra);
+  }
+
+  return (
+    <div className={styles.formBox}>
+      <p className={styles.formTitle}>Sign Up — {ev.title}</p>
+
+      {ev.type === 'tournament' && (
+        <>
+          <label className={styles.label}>Division</label>
+          {config?.divisions?.length > 0 ? (
+            <>
+              <select className={styles.input} value={division} onChange={e => { setDivision(e.target.value); setDivisionError(false); }}>
+                <option value="">Select division</option>
+                {config.divisions.map(d => <option key={d} value={d}>{d}</option>)}
+              </select>
+              {divisionError && <span className={styles.fieldError}>Please select a division.</span>}
+            </>
+          ) : (
+            <input className={styles.input} placeholder="Division" value={division}
+              onChange={e => setDivision(e.target.value)} />
+          )}
+          <label className={styles.label}>
+            <input type="checkbox" checked={doingTeams} onChange={e => setDoingTeams(e.target.checked)} />{' '}
+            Doing teams
+          </label>
+          {config?.shinpan_needed && (
+            <label className={styles.label}>
+              <input type="checkbox" checked={shinpanning} onChange={e => setShinpanning(e.target.checked)} />{' '}
+              Shinpanning
+            </label>
+          )}
+        </>
+      )}
+
+      {ev.type === 'shinsa' && (
+        <>
+          <label className={styles.label}>Testing for</label>
+          {config?.shinsa_levels?.length > 0 ? (
+            <select className={styles.input} value={testingFor} onChange={e => setTestingFor(e.target.value)}>
+              <option value="">Select level</option>
+              {config.shinsa_levels.map(l => <option key={l} value={l}>{l}</option>)}
+            </select>
+          ) : (
+            <input className={styles.input} placeholder="e.g. 1dan" value={testingFor}
+              onChange={e => setTestingFor(e.target.value)} />
+          )}
+        </>
+      )}
+
+      {ev.type === 'seminar' && (
+        <p className={styles.cardDesc}>Click confirm to register for this seminar.</p>
+      )}
+
+      <div className={styles.formActions}>
+        <button className={styles.saveBtn} onClick={handleSubmit} disabled={submitting}>
+          {submitting ? 'Registering...' : 'Confirm'}
+        </button>
+        <button className={styles.cancelBtn} onClick={onCancel} disabled={submitting}>Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+function EventsSignup() {
+  const [events, setEvents] = useState([]);
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState('All');
+  const [configs, setConfigs] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [signingUpId, setSigningUpId] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [registeredIds, setRegisteredIds] = useState(new Set());
+  const [toast, setToast] = useState(null);
+  const memberIdRef = useRef(null);
+
+  useEffect(() => {
+    async function loadRegistrations() {
+      const user = await userManager.getUser();
+      console.log('[registrations] user:', user ? 'found' : 'none', 'expired:', user?.expired);
+      if (!user || user.expired) return;
+
+      const email = user.profile?.email;
+      console.log('[registrations] email:', email);
+      if (!email) return;
+
+      try {
+        const membersRes = await fetch(`${MEMBERS_API}?email=${encodeURIComponent(email)}`);
+        const membersData = await membersRes.json();
+        console.log('[registrations] members response:', membersData);
+        if (!membersData.items?.length) return;
+
+        const memberId = membersData.items[0].member_id;
+        console.log('[registrations] memberId:', memberId, '(type:', typeof memberId, ')');
+        memberIdRef.current = memberId;
+
+        const fetchReg = (path) => fetch(`${BASE_URL}${path}`)
+          .then(r => r.json())
+          .catch(() => ({ body: [] }));
+
+        const [tourn, shinsa, seminar] = await Promise.all([
+          fetchReg('/events/tournamentRegistrations'),
+          fetchReg('/events/shinsaRegistrations'),
+          fetchReg('/events/seminarRegistrations'),
+        ]);
+
+        console.log('[registrations] tourn rows:', tourn.body);
+        console.log('[registrations] shinsa rows:', shinsa.body);
+        console.log('[registrations] seminar rows:', seminar.body);
+
+        const match = (r) => Number(r.member_id) === Number(memberId);
+        const ids = new Set([
+          ...(tourn.body || []).filter(match).map(r => r.event_id),
+          ...(shinsa.body || []).filter(match).map(r => r.event_id),
+          ...(seminar.body || []).filter(match).map(r => r.event_id),
+        ]);
+        console.log('[registrations] matched event ids:', [...ids]);
+        setRegisteredIds(ids);
+      } catch (err) {
+        console.error('[registrations] failed:', err);
+      }
+    }
+    loadRegistrations();
+  }, []);
+
+  useEffect(() => {
+    fetch(EVENTS_API)
+      .then(res => { if (!res.ok) throw new Error(`HTTP ${res.status}`); return res.json(); })
+      .then(data => {
+        const evs = data.body.map(e => ({
+          event_id: e.event_id,
+          title: e.event_name,
+          start_datetime: e.event_date,
+          end_datetime: e.event_deadline,
+          location: e.event_location,
+          type: e.event_type,
+        }));
+        setEvents(evs);
+        return evs;
+      })
+      .then(evs =>
+        Promise.all(
+          evs.map(ev =>
+            fetch(`${CONFIGURE_API}?event_id=${ev.event_id}`)
+              .then(r => r.json())
+              .then(r => ({ id: ev.event_id, data: r.data ?? null }))
+              .catch(() => ({ id: ev.event_id, data: null }))
+          )
+        ).then(results => {
+          const map = {};
+          results.forEach(r => { map[r.id] = r.data; });
+          setConfigs(map);
+        })
+      )
+      .catch(err => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filtered = events.filter(ev => {
+    const status = getStatus(ev.start_datetime, ev.end_datetime);
+    const matchFilter = filter === 'All' || status === filter;
+    const matchSearch = ev.title.toLowerCase().includes(search.toLowerCase());
+    return matchFilter && matchSearch;
+  });
+
+  function showToast(msg) {
+    setToast(msg);
+    setTimeout(() => setToast(null), 3000);
+  }
+
+  async function handleSignUpClick(ev) {
+    const user = await userManager.getUser();
+    if (!user || user.expired) {
+      alert('Please sign in to register for events.');
+      return;
+    }
+    setSigningUpId(ev.event_id);
+  }
+
+  async function resolveMemberId() {
+    if (memberIdRef.current != null) return memberIdRef.current;
+    const user = await userManager.getUser();
+    if (!user || user.expired) {
+      alert('Please sign in to register for events.');
+      return null;
+    }
+    const email = user.profile?.email;
+    if (!email) {
+      alert('Could not determine your email. Please sign in again.');
+      return null;
+    }
+    const membersRes = await fetch(`${MEMBERS_API}?email=${encodeURIComponent(email)}`);
+    if (!membersRes.ok) throw new Error(`Could not fetch member info (HTTP ${membersRes.status})`);
+    const membersData = await membersRes.json();
+    if (!membersData.items?.length) {
+      alert('No member account found for your email. Please contact an admin.');
+      return null;
+    }
+    memberIdRef.current = membersData.items[0].member_id;
+    return memberIdRef.current;
+  }
+
+  async function handleSignUpSubmit(ev, extra) {
+    setSubmitting(true);
+    try {
+      const memberId = await resolveMemberId();
+      if (memberId == null) return;
+
+      const payload = {
+        config_type: ev.type,
+        event_id: ev.event_id,
+        member_id: memberId,
+        registration_date: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        ...extra,
+      };
+
+      const res = await fetch(REGISTER_API, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+
+      setRegisteredIds(prev => new Set([...prev, ev.event_id]));
+      setSigningUpId(null);
+      showToast(`Successfully registered for ${ev.title}.`);
+    } catch (err) {
+      alert(`Registration failed: ${err.message}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleUnregister(ev) {
+    setSubmitting(true);
+    try {
+      const memberId = await resolveMemberId();
+      if (memberId == null) return;
+
+      const res = await fetch(REGISTER_API, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ config_type: ev.type, event_id: ev.event_id, member_id: memberId }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+
+      setRegisteredIds(prev => { const next = new Set(prev); next.delete(ev.event_id); return next; });
+      showToast(`Successfully unregistered from ${ev.title}.`);
+    } catch (err) {
+      alert(`Unregister failed: ${err.message}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className={styles.page}>
+      {toast && <div className={styles.toast}>{toast}</div>}
+      <div className={styles.header}>
+        <div>
+          <h2 className={styles.title}>Events</h2>
+          <span className={styles.count}>{events.length} events</span>
+        </div>
+        <input
+          className={styles.search}
+          placeholder="Search events..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+      </div>
+
+      <div className={styles.filters}>
+        <span className={styles.filtersLabel}>Filter:</span>
+        {['All', 'Upcoming', 'Ongoing', 'Past'].map(f => (
+          <button
+            key={f}
+            className={`${styles.filterBtn} ${filter === f ? styles.filterActive : ''}`}
+            onClick={() => setFilter(f)}
+          >{f}</button>
+        ))}
+      </div>
+
+      <div className={styles.list}>
+        {loading && <p className={styles.empty}>Loading events...</p>}
+        {error && <p className={styles.empty}>Error: {error}</p>}
+        {!loading && !error && filtered.length === 0 && <p className={styles.empty}>No events found.</p>}
+        {filtered.map(ev => {
+          const status = getStatus(ev.start_datetime, ev.end_datetime);
+          const { day, month } = formatDateBadge(ev.start_datetime);
+          const dateRange = formatDateRange(ev.start_datetime, ev.end_datetime, ev.location);
+          const isSigningUp = signingUpId === ev.event_id;
+          const isRegistered = registeredIds.has(ev.event_id);
+          const cfg = configs[ev.event_id];
+
+          return (
+            <div key={ev.event_id} className={styles.card}>
+              <div className={styles.dateBadge}>
+                <span className={styles.dateDay}>{day}</span>
+                <span className={styles.dateMonth}>{month}</span>
+              </div>
+              <div className={styles.cardBody}>
+                {isSigningUp ? (
+                  <SignUpForm
+                    ev={ev}
+                    config={cfg}
+                    onSubmit={extra => handleSignUpSubmit(ev, extra)}
+                    onCancel={() => setSigningUpId(null)}
+                    submitting={submitting}
+                  />
+                ) : (
+                  <>
+                    <div className={styles.cardTop}>
+                      <span className={styles.cardTitle}>{ev.title}</span>
+                      <span className={styles.badge} style={{ backgroundColor: STATUS_COLORS[status] }}>{status}</span>
+                      <span className={styles.typeBadge}>{ev.type}</span>
+                      {isRegistered && (
+                        <span className={styles.badge} style={{ backgroundColor: '#157347' }}>Registered</span>
+                      )}
+                    </div>
+                    <p className={styles.cardMeta}>{dateRange}</p>
+                    {cfg && (
+                      <div className={styles.configSection}>
+                        {ev.type === 'tournament' && (<>
+                          {cfg.divisions?.length > 0 && (
+                            <div className={styles.configRow}>
+                              <span className={styles.configLabel}>Divisions</span>
+                              <div className={styles.configTags}>
+                                {cfg.divisions.map(d => <span key={d} className={styles.configTag}>{d}</span>)}
+                              </div>
+                            </div>
+                          )}
+                          {cfg.teams_included != null && (
+                            <div className={styles.configRow}>
+                              <span className={styles.configLabel}>Teams</span>
+                              <span className={cfg.teams_included ? styles.configBoolTrue : styles.configBoolFalse}>
+                                {cfg.teams_included ? 'Yes' : 'No'}
+                              </span>
+                            </div>
+                          )}
+                        </>)}
+                        {ev.type === 'shinsa' && cfg.shinsa_levels?.length > 0 && (
+                          <div className={styles.configRow}>
+                            <span className={styles.configLabel}>Levels</span>
+                            <div className={styles.configTags}>
+                              {cfg.shinsa_levels.map(l => <span key={l} className={styles.configTag}>{l}</span>)}
+                            </div>
+                          </div>
+                        )}
+                        {ev.type === 'seminar' && cfg.seminar_guests?.length > 0 && (
+                          <div className={styles.configRow}>
+                            <span className={styles.configLabel}>Guests</span>
+                            <div className={styles.configTags}>
+                              {cfg.seminar_guests.map(g => <span key={g} className={styles.configTag}>{g}</span>)}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                    <div className={styles.cardActions}>
+                      {status !== 'Past' && !isRegistered && (
+                        <button className={styles.signupBtn} onClick={() => handleSignUpClick(ev)}>
+                          Sign Up
+                        </button>
+                      )}
+                      {isRegistered && (
+                        <button className={styles.deleteBtn} onClick={() => handleUnregister(ev)} disabled={submitting}>
+                          Unregister
+                        </button>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default EventsSignup;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -5,6 +5,7 @@ import * as buttonLogic from '../js/buttonLogic.js';
 import { userManager } from '../js/cognitoManager.js';
 import AdminDashboard from './AdminDashboard.jsx';
 import AdminControl from './AdminControl.jsx';
+import EventsSignup from './EventsSignup.jsx';
 
 const BASE_TABS = ['Nafudakake', 'Pay', 'Events'];
 
@@ -19,8 +20,11 @@ const Content = ({ activeTab }) => {
   if (activeTab === 'Nafudakake') {
     return null;
   }
-  if(activeTab === 'Admin Control'){
+  if (activeTab === 'Admin Control') {
     return <AdminControl />;
+  }
+  if (activeTab === 'Events') {
+    return <EventsSignup />;
   }
   return <Placeholder title={activeTab} />;
 };

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,10 +2,11 @@ import React, { useState, useEffect } from 'react';
 import { renderTable, layoutShelf, setupEventListeners } from '../js/nafudaManager.js';
 
 import * as buttonLogic from '../js/buttonLogic.js';
+import { userManager } from '../js/cognitoManager.js';
 import AdminDashboard from './AdminDashboard.jsx';
 import AdminControl from './AdminControl.jsx';
 
-const tabs = ['Nafudakake', 'Pay', 'Events', 'Admin Control'];
+const BASE_TABS = ['Nafudakake', 'Pay', 'Events'];
 
 const Placeholder = ({ title }) => (
   <div className='p-4 bg-white border rounded shadow-sm text-center text-muted'>
@@ -26,6 +27,31 @@ const Content = ({ activeTab }) => {
 
 export default function App() {
   const [activeTab, setActiveTab] = useState('Nafudakake');
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    async function checkAdmin() {
+      const user = await userManager.getUser();
+      if (!user || user.expired) return;
+      try {
+        const res = await fetch('https://qh3c0tz6s9.execute-api.us-east-2.amazonaws.com/admins', {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${user.id_token}`
+          }
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        setIsAdmin(!!data.isAdmin);
+      } catch {
+        // not admin
+      }
+    }
+    checkAdmin();
+  }, []);
+
+  const tabs = isAdmin ? [...BASE_TABS, 'Admin Control'] : BASE_TABS;
 
   useEffect(() => {
     const nafudakakeContent = document.getElementById('nafudakake-content');

--- a/infra/lambdas/events/createEvent/index.js
+++ b/infra/lambdas/events/createEvent/index.js
@@ -43,6 +43,27 @@ exports.handler = async (event) => {
         const eventDate = parameters.event_date;
         const eventDeadline = parameters.event_deadline;
         const eventLocation = parameters.event_location;
+        const paymentId = parameters.payment_id ? parseInt(parameters.payment_id, 10) : null;
+
+        if (!paymentId) {
+            return {
+                statusCode: 400,
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ error: "payment_id is required to create an event." }),
+            };
+        }
+
+        const conflict = await query(
+            `SELECT event_id FROM ${EVENTS_TABLE} WHERE payment_id = $1 LIMIT 1`,
+            [paymentId]
+        );
+        if (conflict.rowCount > 0) {
+            return {
+                statusCode: 409,
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ error: `payment_id ${paymentId} is already linked to event ${conflict.rows[0].event_id}.` }),
+            };
+        }
 
         const result = await query(
             `
@@ -53,9 +74,10 @@ exports.handler = async (event) => {
                 event_type,
                 event_deadline,
                 created_at,
-                event_location
+                event_location,
+                payment_id
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             RETURNING
                 event_id,
                 event_date,
@@ -63,7 +85,8 @@ exports.handler = async (event) => {
                 event_type,
                 event_deadline,
                 created_at,
-                event_location
+                event_location,
+                payment_id
             `,
             [
                 newEventId,
@@ -73,6 +96,7 @@ exports.handler = async (event) => {
                 eventDeadline,
                 createdAt,
                 eventLocation,
+                paymentId,
             ]
         );
 

--- a/infra/lambdas/events/registerEvent/index.js
+++ b/infra/lambdas/events/registerEvent/index.js
@@ -1,5 +1,6 @@
 const { query } = require("../../shared_utils/db");
 const { verifyMemberExists } = require("../../shared_utils/members");
+const { getCurrentTimeUTC } = require("../../shared_utils/dates");
 
 const TOURNAMENT_REGISTRATION_TABLE = "tournament_registrations";
 const SHINSA_REGISTRATION_TABLE = "shinsa_registrations";
@@ -23,6 +24,8 @@ exports.handler = async (event) => {
             };
         }
 
+        let registrationData;
+
         if (configType === "tournament") {
             const shinpanning = parameters.shinpanning;
             const division = parameters.division;
@@ -31,109 +34,79 @@ exports.handler = async (event) => {
             const result = await query(
                 `
                 INSERT INTO ${TOURNAMENT_REGISTRATION_TABLE} (
-                    event_id,
-                    member_id,
-                    registration_date,
-                    shinpanning,
-                    division,
-                    doing_teams
+                    event_id, member_id, registration_date, shinpanning, division, doing_teams
                 )
                 VALUES ($1, $2, $3, $4, $5, $6)
-                RETURNING
-                    event_id,
-                    member_id,
-                    registration_date,
-                    shinpanning,
-                    division,
-                    doing_teams
+                RETURNING event_id, member_id, registration_date, shinpanning, division, doing_teams
                 `,
                 [eventId, memberId, registeredDate, shinpanning, division, doingTeams]
             );
+            registrationData = result.rows[0];
 
-            return {
-                statusCode: 200,
-                headers: {
-                    "Content-Type": "application/json",
-                    "Access-Control-Allow-Origin": "*"
-                },
-                body: JSON.stringify({
-                    message: "Registered Event Successfully",
-                    config_type: configType,
-                    data: result.rows[0],
-                })
-            };
-        }
-
-        if (configType === "shinsa") {
+        } else if (configType === "shinsa") {
             const testingFor = parameters.testing_for;
 
             const result = await query(
                 `
                 INSERT INTO ${SHINSA_REGISTRATION_TABLE} (
-                    event_id,
-                    member_id,
-                    registration_date,
-                    testing_for
+                    event_id, member_id, registration_date, testing_for
                 )
                 VALUES ($1, $2, $3, $4)
-                RETURNING
-                    event_id,
-                    member_id,
-                    registration_date,
-                    testing_for
+                RETURNING event_id, member_id, registration_date, testing_for
                 `,
                 [eventId, memberId, registeredDate, testingFor]
             );
+            registrationData = result.rows[0];
 
-            return {
-                statusCode: 200,
-                headers: {
-                    "Content-Type": "application/json",
-                    "Access-Control-Allow-Origin": "*"
-                },
-                body: JSON.stringify({
-                    message: "Registered Event Successfully",
-                    config_type: configType,
-                    data: result.rows[0],
-                })
-            };
-        }
-
-        if (configType === "seminar") {
+        } else if (configType === "seminar") {
             const result = await query(
                 `
                 INSERT INTO ${SEMINAR_REGISTRATION_TABLE} (
-                    event_id,
-                    member_id,
-                    registration_date
+                    event_id, member_id, registration_date
                 )
                 VALUES ($1, $2, $3)
-                RETURNING
-                    event_id,
-                    member_id,
-                    registration_date
+                RETURNING event_id, member_id, registration_date
                 `,
                 [eventId, memberId, registeredDate]
             );
+            registrationData = result.rows[0];
 
+        } else {
             return {
-                statusCode: 200,
-                headers: {
-                    "Content-Type": "application/json",
-                    "Access-Control-Allow-Origin": "*"
-                },
-                body: JSON.stringify({
-                    message: "Registered Event Successfully",
-                    config_type: configType,
-                    data: result.rows[0],
-                })
+                statusCode: 400,
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ error: "Invalid config_type" })
             };
         }
 
+        // Assign member to the event's linked payment if one exists
+        const eventResult = await query(
+            `SELECT payment_id FROM events WHERE event_id = $1 LIMIT 1`,
+            [eventId]
+        );
+        const paymentId = eventResult.rows[0]?.payment_id;
+        if (paymentId) {
+            await query(
+                `
+                INSERT INTO assigned_payments (member_id, payment_id, assigned_on, due_status)
+                VALUES ($1, $2, $3, $4)
+                ON CONFLICT DO NOTHING
+                `,
+                [memberId, paymentId, getCurrentTimeUTC(), "due"]
+            );
+        }
+
         return {
-            statusCode: 400,
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ error: "Invalid config_type" })
+            statusCode: 200,
+            headers: {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Origin": "*"
+            },
+            body: JSON.stringify({
+                message: "Registered Event Successfully",
+                config_type: configType,
+                data: registrationData,
+            })
         };
 
     } catch (err) {

--- a/infra/lambdas/events/unregisterEvent/index.js
+++ b/infra/lambdas/events/unregisterEvent/index.js
@@ -75,6 +75,19 @@ exports.handler = async (event) => {
             };
         }
 
+        // Remove the member's assigned payment for this event if one exists
+        const eventResult = await query(
+            `SELECT payment_id FROM events WHERE event_id = $1 LIMIT 1`,
+            [eventId]
+        );
+        const paymentId = eventResult.rows[0]?.payment_id;
+        if (paymentId) {
+            await query(
+                `DELETE FROM assigned_payments WHERE member_id = $1 AND payment_id = $2`,
+                [memberId, paymentId]
+            );
+        }
+
         return {
             statusCode: 200,
             headers: {

--- a/infra/lambdas/events/updateEvent/index.js
+++ b/infra/lambdas/events/updateEvent/index.js
@@ -88,6 +88,20 @@ exports.handler = async (event) => {
             };
         }
 
+        if (payload.payment_id) {
+            const conflict = await query(
+                `SELECT event_id FROM ${EVENTS_TABLE} WHERE payment_id = $1 AND event_id != $2 LIMIT 1`,
+                [payload.payment_id, eventId]
+            );
+            if (conflict.rowCount > 0) {
+                return {
+                    statusCode: 409,
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ error: `payment_id ${payload.payment_id} is already linked to event ${conflict.rows[0].event_id}.` }),
+                };
+            }
+        }
+
         const updateKeys = Object.keys(payload);
 
         const setClause = updateKeys


### PR DESCRIPTION
closes #175 

allow client users to be able to view the available events and sign up for them. Signing up for an event results in the user logged into the database under the various events sign up tables. Additionally, every event should have an associated payment, and the user will be auto assigned to that payment when they sign up for an event

on the admin control panel, the admin now has the ability to link payment_id(s) to a created or existing event. They will need to make sure that they have a dedicated payment for an event